### PR TITLE
Bump nokogiri from 1.10.1 to 1.10.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.2)
     newrelic_rpm (6.0.0.351)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (0.18.1)
     pry (0.10.1)
@@ -244,4 +244,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
`bundle update nokogiri`

Addresses [CVE-2019-5477][1].

[1]: https://nvd.nist.gov/vuln/detail/CVE-2019-5477